### PR TITLE
Redraw now returns a bool indicating if something was drawn

### DIFF
--- a/include/cairoSurfaceImage.h
+++ b/include/cairoSurfaceImage.h
@@ -24,7 +24,7 @@ namespace ecolab
   struct CairoSurface
   {
     Exclude<cairo::SurfacePtr> surface;
-    virtual void redraw(int x0, int y0, int width, int height)=0;
+    virtual bool redraw(int x0, int y0, int width, int height)=0;
     virtual void redrawWithBounds() {redraw(-1e9,-1e9,2e9,2e9);} //TODO better name for this?
     virtual ~CairoSurface() {}
     // arrange a callback with the drawing time in seconds

--- a/include/plot.h
+++ b/include/plot.h
@@ -172,7 +172,7 @@ namespace ecolab
     }
     
     /// redraw the plot
-    void redraw();
+    bool redraw();
     /// draw the plot onto a given surface
     virtual void draw(cairo::Surface&);
     void draw(cairo_t*, double width, double height) const;

--- a/src/plot.cc
+++ b/src/plot.cc
@@ -919,7 +919,7 @@ namespace ecolab
 #endif    
   }
   
-  void Plot::redraw()
+  bool Plot::redraw()
   {
 #if defined(CAIRO)
     if (surface)
@@ -927,8 +927,10 @@ namespace ecolab
         surface->clear();
         draw(*surface);
         surface->blit();
+        return true;
       }
 #endif
+    return false;
   }
         
   void Plot::clear()


### PR DESCRIPTION
Redraw now returns a `bool` indicating if something was drawn on the surface or not. This helps us optimize the dummy png buffer redraws in renderNativeWindow (they are needed only when model goes out of screen).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/ecolab/11)
<!-- Reviewable:end -->
